### PR TITLE
Remove the session.details() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ A client for working with the Ft Next service from the front-end.
 
 	var session = require('ft-next-session-client');
 
+	session.validate().then(function(isValid){
+		// true or false
+	});
+
 	// get uuid from session
 	session.uuid().then(function(data){
 		// data will be false if session is invalid

--- a/README.md
+++ b/README.md
@@ -12,16 +12,6 @@ A client for working with the Ft Next service from the front-end.
 
 	var session = require('ft-next-session-client');
 
-	// check if current session is valid
-	session.validate().then(function(isValid){
-		// true or false
-	});
-
-	// check session details
-	session.details().then(function(sessionDetails){
-		// object or false if session is invalid
-	});
-
 	// get uuid from session
 	session.uuid().then(function(data){
 		// data will be false if session is invalid
@@ -33,4 +23,4 @@ A client for working with the Ft Next service from the front-end.
 
 ## Note
 
-The `details` and `uuid` methods are cached server-side.  If you need to be sure that the user is logged in, use `validate()`.
+The `uuid` method is cached server-side.  If you need to be sure that the user is logged in, use `validate()`.

--- a/main.js
+++ b/main.js
@@ -3,25 +3,6 @@ var request  = require('./src/request');
 var cache = require('./src/cache');
 var promises = {};
 
-function details(){
-	// cache contains products then we must've already done a details call
-	if (cache('products')){
-		return Promise.resolve(cache());
-	}
-	if (!promises.session) {
-		promises.session = request('/').then(function(sessionDetails){
-			if(sessionDetails){
-				cache(sessionDetails);
-			}
-			return sessionDetails;
-		});
-		promises.uuid = promises.uuid || promises.session.then(function (sessionDetails) {
-			return {uuid: sessionDetails.uuid};
-		});
-	}
-	return promises.session;
-}
-
 function uuid(){
 	var uuid = cache('uuid')
 
@@ -45,7 +26,6 @@ function validate(){
 }
 
 module.exports = {
-	details : details,
 	uuid : uuid,
 	validate : validate,
 	cache : cache,

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -50,7 +50,6 @@ describe('Session Client', function(){
 	it('Should be able to get session uuid', function(done){
 		setup({uuid:sessionData.uuid}, true);
 		session.uuid().then(function(response){
-			debugger;
 			expect(response.uuid).to.equal(sessionData.uuid);
 			done();
 		}).catch(done);

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -9,12 +9,13 @@ describe('Session Client', function(){
 
 	var jsonpCallbackName = '$$$JSONP_CALLBACK';
 
-	var sessionData = {"erightsId":"11624548","passportId":"4011624548","uuid":"e1d24b36-30de-434d-a087-e04c17377ac7","title":"Mr","firstName":"Paul","lastName":"Wilson","emailAddress":"paul.i.wilson@ft.com","groups":"FT Current Staff,Organisations,Individuals","products":"P0,Tools,P2"};
+	var sessionData = {"uuid":"e1d24b36-30de-434d-a087-e04c17377ac7"};
 
 	before(function(){
 		if(document.cookie.indexOf('FTSession=') < 0){
 			document.cookie += 'FTSession=0-HSSzYw3kNN06CH4EwXN3rHzwAAAU1NL7xtww.MEYCIQDXxFJypS8uRn86Fjlcw9wVrf2vzC2kkd9XbcJmZpenrwIhAP0q2fTmfBa0WkJzGtnrwfcuIl3oBxXzwabrcHXE41xi';
 		}
+		session.cache.clear();
 	});
 
 	afterEach(function(){
@@ -46,17 +47,10 @@ describe('Session Client', function(){
 		setupJsonp(data, success);
 	}
 
-	it('Should be able to get session details', function(done){
-		setup(sessionData, true);
-		session.details().then(function(sessionDetails){
-			expect(sessionDetails).to.deep.equal(sessionData);
-			done();
-		}).catch(done);
-	});
-
 	it('Should be able to get session uuid', function(done){
 		setup({uuid:sessionData.uuid}, true);
 		session.uuid().then(function(response){
+			debugger;
 			expect(response.uuid).to.equal(sessionData.uuid);
 			done();
 		}).catch(done);


### PR DESCRIPTION
We don't use this API at the moment and having it here increases the exposure to CSRF.

We are removing the ability to use the session API from non-FT domains with CORS and restricting JSONP to a single endpoint, so the details() API will stop working in several cases anyway.