### PR TITLE
Distinct uuid cache for uuid and products requests

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ function uuid(){
 
 function products(){
 	const cachedProducts = cache('products');
-	const cachedUUID = cache('uuid');
+	const cachedUUID = cache('uuid-products');
 
 	if(cachedProducts && cachedUUID){
 		return Promise.resolve({products:cachedProducts, uuid:cachedUUID});
@@ -32,7 +32,7 @@ function products(){
 	if(!promises.products){
 		promises.products = request('/products').then(function(response){
 			cache('products', response.products);
-			cache('uuid', response.uuid);
+			cache('uuid-products', response.uuid);
 			return response;
 		});
 	}


### PR DESCRIPTION
Currently we share the uuid cache between what the `/uuid` endpoint returns and what `/products` does.

Temporarily make them distinct, see if that has an effect on https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dheroku%20source%3D%22%2Fvar%2Flog%2Fapps%2Fheroku%2Fft-next-api.log%22%20event%3DRESPONSE_ERROR%20status_code%3D403%20error_message%3D%22*not%20authorised*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&earliest=-6h&latest=now&display.events.fields=%5B%22status_code%22%2C%22error_message%22%5D&sid=1486657572.245556

@commuterjoy 