### PR TITLE
Don't cache uuid

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,11 +14,6 @@ const getSessionId = () => {
 };
 
 const getUuid = () => {
-	const cachedUUID = cache('uuid');
-	if (cachedUUID) {
-		return Promise.resolve({ uuid: cachedUUID });
-	}
-
 	const sessionId = getSessionId();
 	if (!sessionId) {
 		return Promise.resolve({ uuid: undefined });
@@ -28,9 +23,6 @@ const getUuid = () => {
 		requests.uuid = request(`/sessions/s/${sessionId}`)
 			.then(({ uuid } = {}) => {
 				delete requests.uuid;
-				if (uuid) {
-					cache('uuid', uuid);
-				}
 				return { uuid };
 			});
 	}


### PR DESCRIPTION
Testing whether this fixes an issue where a uuid is being sent to next-api, but no cookies; possibly the uuid is from the cache, but there's some cookie restriction in place...