### PR TITLE
Add Snyk to components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
+      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/next-session-client
       - run:
           name: shared-helper / npm-version-and-publish-public
           command: .circleci/shared-helpers/helper-npm-version-and-publish-public

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lintspaces-cli": "^0.6.0",
     "mocha": "^3.2.0",
     "sinon": "^1.14.1",
+    "snyk": "^1.168.0",
     "webpack": "^2.2.1"
   },
   "engines": {
@@ -29,6 +30,7 @@
   "scripts": {
     "precommit": "node_modules/.bin/secret-squirrel",
     "prepush": "make test && make verify -j3",
-    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg"
+    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   }
 }


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our repos for security reasons. It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building. See https://github.com/Financial-Times/next/issues/365