### PR TITLE
Upgrade Node version -> v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@
 
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node12: &container_config_node12
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:12-browsers
 
-  container_config_lambda_node8: &container_config_lambda_node8
+  container_config_lambda_node12: &container_config_lambda_node12
     working_directory: ~/project/build
     docker:
-      - image: lambci/lambda:build-nodejs8.10
+      - image: lambci/lambda:build-nodejs12.x
 
   workspace_root: &workspace_root
     ~/project
@@ -60,7 +60,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node12
     steps:
       - checkout
       - run:
@@ -90,7 +90,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node12
     steps:
       - *attach_workspace
       - run:
@@ -106,7 +106,7 @@ jobs:
           destination: test-results
 
   publish:
-    <<: *container_config_node8
+    <<: *container_config_node12
     steps:
       - *attach_workspace
       - run:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "webpack": "^2.2.1"
   },
   "engines": {
-    "node": "^6"
+    "node": "12.x"
   },
   "scripts": {
     "precommit": "node_modules/.bin/secret-squirrel",


### PR DESCRIPTION
This app uses two different Node versions in different contexts:
- **v6** in `package.json`.
- **v8** in the CircleCI image.

This PR updates it to use **v12** in both cases, which also brings it up to date with the Node version used by the apps that consume this tool:
- `next-front-page`: `"node": "12.x"`.
- `next-article`: `"node": "12.x"`.
- `next-globetrotter`: `"node": "^12.16.0"`.
- `n-syndication`: `"node": "^8.11.1"` (I will put in a separate PR to update this).
- `n-myft-ui`: Not stated.
- `next-myft-client`: Not stated.