### PR TITLE
Add renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "github>financial-times/renovate-config-next"
+  ]
+}


### PR DESCRIPTION
I can see that the Renovate app has already been installed to this repo.

It would therefore make sense to used the shared Renovate settings, so this PR adds the `renovate.json` to do that.

#### References:
- [Financial-Times/next: Renovate - Adding Renovate to a repository](https://github.com/Financial-Times/next/wiki/Renovate#adding-renovate-to-a-repository).