### PR TITLE
chore: remove package.json from bowerignore file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,7 @@
     "Makefile",
     "circle.yml",
     "ft.yml",
-    "n.makefile",
-    "package.json"
+    "n.makefile"
   ],
   "homepage": "https://github.com/Financial-Times/next-session-client"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "next-session-client",
-  "version": "0.0.0",
+  "version": "3.0.0",
+  "main": "main.js",
   "devDependencies": {
     "@financial-times/n-gage": "^5.0.0",
     "babel-core": "^6.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-session-client",
-  "version": "3.0.0",
+  "version": "0.0.0",
   "main": "main.js",
   "devDependencies": {
     "@financial-times/n-gage": "^5.0.0",


### PR DESCRIPTION
The PR removes the `package.json` file from bowerignore in order for it to be included in when we use the dependency in [n-syndication](https://github.com/Financial-Times/n-syndication)

### Problem
Our test suite is failing due to the exclusion of the `package.json`
```
  ● Test suite failed to run
    Cannot find module 'next-session-client' from 'src/js/index.js'
    Require stack:
      src/js/index.js
      test/src/js/index.spec.js
      1 | import {$$} from 'n-ui-foundations';
    > 2 | import {products as getUserProducts} from 'next-session-client';
        |                          ^
      3 | import getUserStatus from './get-user-status';
      4 | import {init as initDataStore} from './data-store';
      5 | import {init as initIconify} from './iconify';
      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:306:11)
      at Object.<anonymous> (src/js/index.js:2:26)
```

### Concern
We would like to understand if there is a larger impact of including the `package.json` to other projects that use `next-session-client`.

The `package.json` file was excluded with this [PR](https://github.com/Financial-Times/next-session-client/pull/29/files), however, it isn't clear what the rational was.