### PR TITLE
CPP-442 Upgrade GitHub repos from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,9 @@ references:
     restore_cache:
         <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -165,7 +165,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,6 @@
 _extends: github-apps-config-next
 branches:
-  - name: master
+  - name: main
     protection:
       required_pull_request_reviews: null
       required_status_checks:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Next Session Client
-[![Build Status](https://snap-ci.com/Financial-Times/next-session-client/branch/master/build_image)](https://snap-ci.com/Financial-Times/next-session-client/branch/master)
+[![Build Status](https://snap-ci.com/Financial-Times/next-session-client/branch/HEAD/build_image)](https://snap-ci.com/Financial-Times/next-session-client/branch/master)
 
 A client for working with the [Next Session service](https://github.com/Financial-Times/next-session).
 


### PR DESCRIPTION
[Ticket CPP-442 Upgrade GitHub repos from `master` to `main`](https://financialtimes.atlassian.net/browse/CPP-442)<br/><br/>As an organisation we are moving away from the usage of `master` as a central branch and switching it to `main`, this is to avoid using unnecessary language that can be offensive. This PR is for making those changes. <br/><br/>This PR was created using a nori script<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._