### PR TITLE
CPP-442 remove master reference and fixed circleci svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Next Session Client
-[![Build Status](https://snap-ci.com/Financial-Times/next-session-client/branch/HEAD/build_image)](https://snap-ci.com/Financial-Times/next-session-client/branch/master)
+[![CircleCI](https://circleci.com/gh/Financial-Times/next-session-client/tree/main.svg?style=svg)](https://circleci.com/gh/Financial-Times/next-session-client/tree/main)
 
 A client for working with the [Next Session service](https://github.com/Financial-Times/next-session).
 


### PR DESCRIPTION
my nori script missed this reference to master, while fixing it I realized that the circleci svg link was outdated so I fixed that as well