### PR TITLE
Don't force dependents to use npm 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "npm_config_yes=true npx check-engine"
+    "preinstall": "[[ \"$INIT_CWD\" != \"$PWD\" ]] || npm_config_yes=true npx check-engine"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
The `check-engine` script we were using to enforce npm 7 usage when developing locally was also being run when the package was installed by other consumers, causing the installation to fail if they were using an npm version other than 7. This is an unnecessarily restrictive requirement which would mean the npm 7 update was a breaking change -- not our intention. Instead, only run the version check when installing the project directly, not when it's installed as a dependency.