### PR TITLE
CPP-642 migrate from circleci/* to cimg/*

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:12-browsers
+      - image: cimg/node:12.22-browsers
 
   workspace_root: &workspace_root
     ~/project
@@ -60,6 +60,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@4.6.0
+  browser-tools: circleci/browser-tools@1.2.3
 
 jobs:
 
@@ -93,6 +94,7 @@ jobs:
     <<: *container_config_node
     steps:
       - *attach_workspace
+      - browser-tools/install-firefox
       - run:
           name: Run tests
           command: make test


### PR DESCRIPTION
These images will be EOL from Dec 31st, and we should migrate to the modern cimg/* equivalents.