### PR TITLE
update config for nightly scheduled-pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,11 @@ workflows:
   version: 2
 
   build-test:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - build:
           filters:
@@ -157,6 +162,11 @@ workflows:
               node-version: [ "16.14", "14.19" ]
 
   build-test-publish:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - build:
           filters:
@@ -182,6 +192,11 @@ workflows:
             - test-v16.14
 
   renovate-nori-build-test:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - waiting-for-approval:
           type: approval
@@ -203,11 +218,14 @@ workflows:
               node-version: [ "16.14", "14.19" ]
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            <<: *filters_only_main
+    when:
+      and:
+        - equal:
+            - scheduled_pipeline
+            - << pipeline.trigger_source >>
+        - equal:
+            - nightly
+            - << pipeline.schedule.name >>
     jobs:
       - build:
           context: next-nightly-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
             .circleci/shared-helpers
       - *restore_npm_cache
       - node/install-npm:
-          version: "7"
+          version: "7.20.2"
       - run:
           name: Install project dependencies
           command: make install


### PR DESCRIPTION
Applies workflows filtering to your circleci/config.yml, so that the nightly workflow runs with the scheduled trigger, and other workflows won't run with the scheduled trigger.