### PR TITLE
Fix issue with karma failing to start Firefox locally on MacOS

### DIFF
--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -4,9 +4,9 @@ plugins:
   
 hooks:
   test:local:
-    - Karma
+    - KarmaLocal
   test:ci:
-    - Karma
+    - KarmaCI
 
 options:
   "@dotcom-tool-kit/circleci":

--- a/toolkit/karma/index.js
+++ b/toolkit/karma/index.js
@@ -3,7 +3,7 @@ const { spawn } = require('child_process');
 const { hookFork, waitOnExit } = require('@dotcom-tool-kit/logger');
 const karmaCLIPath = require.resolve('karma/bin/karma')
 
-class Karma extends Task {
+class KarmaCI extends Task {
 	async run() {
 		const args = ['start', 'test/karma.conf.js']
 		this.logger.info(`running karma ${args.join(' ')}`)
@@ -13,5 +13,20 @@ class Karma extends Task {
 	}
 }
 
-exports.tasks = [ Karma ];
+class KarmaLocal extends KarmaCI {
+	async run() {
+		// karma-firefox-launcher no longer works for Firefox versions > 121 on MacOS
+		// This is a temporary fix while they release a permanent fix for the issue
+		// See https://github.com/karma-runner/karma-firefox-launcher/issues/328
+		if (process.platform !== 'darwin') {
+			return super.run()
+		}
+
+		process.env.FIREFOX_BIN = '/Applications/Firefox.app/Contents/MacOS/firefox' 
+
+		super.run()
+	}
+}
+
+exports.tasks = [ KarmaCI, KarmaLocal ];
 


### PR DESCRIPTION
## Description

These changes amend the path of `FIREFOX_BIN` on MacOS systems

This issue has been [raised](https://github.com/karma-runner/karma-firefox-launcher/issues/328) on `karma-firefox-launcher` but it's yet to be released
